### PR TITLE
Fix proposal.sol not using all storage variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,10 +386,11 @@ contract Proposal {
     
     function approve(address approver) public {
         approvalMask |= bytes32(approver);
+        approvals[approver] = true;
     }
     
     function isApproved() public constant returns(bool) {
-        return approvalMask == approver1 | approver2;
+        return approvalMask == target;
     }
 }
 

--- a/proposal.sol
+++ b/proposal.sol
@@ -16,9 +16,10 @@ contract Proposal {
     
     function approve(address approver) public {
         approvalMask |= bytes32(approver);
+        approvals[approver] = true;
     }
     
     function isApproved() public constant returns(bool) {
-        return approvalMask == approver1 | approver2;
+        return approvalMask == target;
     }
 }


### PR DESCRIPTION
Adds `approver` to `approvals` map and uses `target` in `isApproved()`.

Alternatively could remove `approvals` and `target` to simplify storage and lower some costs.