### PR TITLE
Fix send-eth.sol's `call()` check

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,9 +542,10 @@ contract MyContract {
         // RECOMMENDED
         // send all remaining gas
         // explicitly handle callee throw
-        if(a.call.value(1 ether)()) throw;
+        if(!a.call.value(1 ether)()) throw;
     }
 }
+
 ```
 
 ### sha3.sol

--- a/send-eth.sol
+++ b/send-eth.sol
@@ -15,6 +15,6 @@ contract MyContract {
         // RECOMMENDED
         // send all remaining gas
         // explicitly handle callee throw
-        if(a.call.value(1 ether)()) throw;
+        if(!a.call.value(1 ether)()) throw;
     }
 }


### PR DESCRIPTION
`.call()` returns `false` on error, rather than `true`.

Alternatively could use the newer `require()`, but other contracts haven't been updated to use that yet.